### PR TITLE
QtDllPath is added to in front of the existing PATH variable.

### DIFF
--- a/QtMSBuild/QtMsBuild/qt_private.props
+++ b/QtMSBuild/QtMsBuild/qt_private.props
@@ -154,7 +154,7 @@
   // -->
   <PropertyGroup>
     <LocalDebuggerEnvironment  Condition="'$(QtDllPath)' != ''"
-      >PATH=%PATH%;$(QtDllPath)&#xD;&#xA;$(LocalDebuggerEnvironment)
+      >PATH=$(QtDllPath);%PATH%&#xD;&#xA;$(LocalDebuggerEnvironment)
     </LocalDebuggerEnvironment>
   </PropertyGroup>
 


### PR DESCRIPTION
QtDllPath is added to in front of the existing PATH environment variable to prevent conflicting with Qt binaries installed in other application.