### PR TITLE
Modified for -no-zstd support in rcc and OpenGLWidgets module in Qt6

### DIFF
--- a/QtMSBuild/QtMSBuild.csproj
+++ b/QtMSBuild/QtMSBuild.csproj
@@ -255,6 +255,11 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </Content>
+    <Content Include="QtMSBuild\rcc\qtrcc_v3.xml">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>qtrcc_v3.xml_TT</DependentUpon>
+    </Content>
     <!--
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // Qt/MSBuild rcc property pages and targets
@@ -278,16 +283,9 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <OutputFile>rcc\qtrcc_v3.xml</OutputFile>
       <DependsOn>$(SolutionDir)\version.targets;$(SolutionDir)\version.tt;$(SolutionDir)\common.tt</DependsOn>
+      <SubType>Designer</SubType>
       <LastGenOutput>qtrcc_v3.xml</LastGenOutput>
-      <SubType>Designer</SubType>
     </T4Template>
-    <Content Include="QtMSBuild\rcc\qtrcc_v3.xml">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>qtrcc_v3.xml_TT</DependentUpon>
-      <SubType>Designer</SubType>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
     <T4Template Include="QtMSBuild\rcc\qtrcc_cl.targets_TT">
       <Generator>TextTemplatingFileGenerator</Generator>
       <OutputFile>rcc\qtrcc_cl.targets</OutputFile>
@@ -387,7 +385,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </Content>
-  <!--
+    <!--
   ///////////////////////////////////////////////////////////////////////////////////////////////
   // Qt/MSBuild translation tools property pages and targets
   // -->

--- a/QtMSBuild/QtMsBuild/rcc/qtrcc.targets
+++ b/QtMSBuild/QtMsBuild/rcc/qtrcc.targets
@@ -259,6 +259,7 @@
                 NoCompression;
                 CompressThreshold;
                 BinaryOutput;
+                NoZstd;
                 PassNumber;
                 NoNamespace;
                 Verbose;
@@ -407,6 +408,14 @@
         <Value Condition="'%(Name)' == 'BinaryOutput' AND '%(Value)' == 'true'">--binary</Value>
       </options>
 
+      <!--//   -no-zstd                 Disable usage of zstd compression -->
+      <options>
+        <Value Condition="'%(Name)' == 'NoZstd' AND '%(Value)' != 'true'"></Value>
+      </options>
+      <options>
+        <Value Condition="'%(Name)' == 'NoZstd' AND '%(Value)' == 'true'">--no-zstd</Value>
+      </options>      
+      
       <!--//   -pass <number>            Pass number for big resources -->
       <options>
         <Value Condition="'%(Name)' == 'PassNumber'">--pass %(Value)</Value>

--- a/QtMSBuild/QtMsBuild/rcc/qtrcc.xml
+++ b/QtMSBuild/QtMsBuild/rcc/qtrcc.xml
@@ -179,6 +179,12 @@
       DisplayName="Binary Output"
       Description="Output a binary file for use as a dynamic resource. (--binary)"
       Switch="--binary"/>
+    <BoolProperty
+      Name="NoZstd"
+      HelpUrl="http://doc.qt.io/qt-5/rcc.html"
+      DisplayName="No Zstd"
+      Description="Disable usage of zstd compression. (--no-zstd)"
+      Switch="--no-zstd"/>
     <StringProperty
       Name="PassNumber"
       HelpUrl="http://doc.qt.io/qt-5/rcc.html"

--- a/QtMSBuild/QtMsBuild/rcc/qtrcc_v3.xml_TT
+++ b/QtMSBuild/QtMsBuild/rcc/qtrcc_v3.xml_TT
@@ -201,6 +201,12 @@
       DisplayName="Binary Output"
       Description="Output a binary file for use as a dynamic resource. (--binary)"
       Switch="--binary"/>
+    <BoolProperty
+      Name="NoZstd"
+      HelpUrl="http://doc.qt.io/qt-5/rcc.html"
+      DisplayName="No Zstd"
+      Description="Output a binary file for use as a dynamic resource. (--no-zstd)"
+      Switch="--no-zstd"/>
     <StringProperty
       Name="PassNumber"
       HelpUrl="http://doc.qt.io/qt-5/rcc.html"

--- a/QtVsTools.Core/QtMsBuild.cs
+++ b/QtVsTools.Core/QtMsBuild.cs
@@ -1044,6 +1044,7 @@ namespace QtVsTools.Core.QtMsBuild
             NoCompression,
             CompressThreshold,
             BinaryOutput,
+            NoZstd,
             PassNumber,
             NoNamespace,
             Verbose,
@@ -1082,6 +1083,9 @@ namespace QtVsTools.Core.QtMsBuild
 
             parser.AddOption(options[Property.BinaryOutput] =
                 new CommandLineOption("binary"));
+
+            parser.AddOption(options[Property.NoZstd] =
+                new CommandLineOption("no-zstd"));
 
             parser.AddOption(options[Property.PassNumber] =
                 new CommandLineOption("pass", "number"));
@@ -1155,6 +1159,9 @@ namespace QtVsTools.Core.QtMsBuild
             if (parser.IsSet(options[Property.BinaryOutput]))
                 properties[Property.BinaryOutput] = "true";
 
+            if (parser.IsSet(options[Property.NoZstd]))
+                properties[Property.NoZstd] = "true";
+
             if (parser.IsSet(options[Property.PassNumber]))
                 properties[Property.PassNumber] = parser.Value(options[Property.PassNumber]);
 
@@ -1209,6 +1216,9 @@ namespace QtVsTools.Core.QtMsBuild
 
             if (container.GetPropertyValue(propertyStorage, Property.BinaryOutput) == "true")
                 GenerateCommandLineOption(cmd, options[Property.BinaryOutput]);
+
+            if (container.GetPropertyValue(propertyStorage, Property.NoZstd) == "true")
+                GenerateCommandLineOption(cmd, options[Property.NoZstd]);
 
             value = container.GetPropertyValue(propertyStorage, Property.PassNumber);
             if (!string.IsNullOrEmpty(value))

--- a/QtVsTools.Package/qt6modules.xml
+++ b/QtVsTools.Package/qt6modules.xml
@@ -221,6 +221,14 @@
     <Defines>QT_OPENGL_LIB</Defines>
   </Module>
   <Module Id="22">
+    <Name>Qt OpenGLWidgets</Name>
+    <Selectable>true</Selectable>
+    <LibraryPrefix>QtOpenGLWidgets</LibraryPrefix>
+    <proVarQT>openglwidgets</proVarQT>
+    <IncludePath>$(QTDIR)\include\QtOpenGLWidgets</IncludePath>
+    <Defines>QT_OPENGLWIDGETS_LIB</Defines>
+  </Module>
+  <Module Id="23">
     <Name>Qt Multimedia</Name>
     <Selectable>true</Selectable>
     <LibraryPrefix>QtMultimedia</LibraryPrefix>
@@ -228,7 +236,7 @@
     <IncludePath>$(QTDIR)\include\QtMultimedia</IncludePath>
     <Defines>QT_MULTIMEDIA_LIB</Defines>
   </Module>
-  <Module Id="23">
+  <Module Id="24">
     <Name>Qt Print Support</Name>
     <Selectable>true</Selectable>
     <LibraryPrefix>QtPrintSupport</LibraryPrefix>
@@ -236,7 +244,7 @@
     <IncludePath>$(QTDIR)\include\QtPrintSupport</IncludePath>
     <Defines>QT_PRINTSUPPORT_LIB</Defines>
   </Module>
-  <Module Id="24">
+  <Module Id="25">
     <Name>Qt Quick Widgets</Name>
     <Selectable>true</Selectable>
     <LibraryPrefix>QtQuickWidgets</LibraryPrefix>
@@ -244,7 +252,7 @@
     <IncludePath>$(QTDIR)\include\QtQuickWidgets</IncludePath>
     <Defines>QT_QUICKWIDGETS_LIB</Defines>
   </Module>
-  <Module Id="25">
+  <Module Id="26">
     <Name>Qt Remote Objects</Name>
     <Selectable>true</Selectable>
     <LibraryPrefix>QtRemoteObjects</LibraryPrefix>
@@ -252,7 +260,7 @@
     <IncludePath>$(QTDIR)\include\QtRemoteObjects</IncludePath>
     <Defines>QT_REMOTEOBJECTS_LIB</Defines>
   </Module>
-  <Module Id="26">
+  <Module Id="27">
     <Name>Qt SCXML</Name>
     <Selectable>true</Selectable>
     <LibraryPrefix>QtScxml</LibraryPrefix>
@@ -260,7 +268,7 @@
     <IncludePath>$(QTDIR)\include\QtScxml</IncludePath>
     <Defines>QT_SCXML_LIB</Defines>
   </Module>
-  <Module Id="27">
+  <Module Id="28">
     <Name>Qt Sensors</Name>
     <Selectable>true</Selectable>
     <LibraryPrefix>QtSensors</LibraryPrefix>
@@ -268,7 +276,7 @@
     <IncludePath>$(QTDIR)\include\QtSensors</IncludePath>
     <Defines>QT_SENSORS_LIB</Defines>
   </Module>
-  <Module Id="28">
+  <Module Id="29">
     <Name>Qt Serial Bus</Name>
     <Selectable>true</Selectable>
     <LibraryPrefix>QtSerialBus</LibraryPrefix>
@@ -276,7 +284,7 @@
     <IncludePath>$(QTDIR)\include\QtSerialBus</IncludePath>
     <Defines>QT_SERIALBUS_LIB</Defines>
   </Module>
-  <Module Id="29">
+  <Module Id="30">
     <Name>Qt Serial Port</Name>
     <Selectable>true</Selectable>
     <LibraryPrefix>QtSerialPort</LibraryPrefix>
@@ -284,7 +292,7 @@
     <IncludePath>$(QTDIR)\include\QtSerialPort</IncludePath>
     <Defines>QT_SERIALPORT_LIB</Defines>
   </Module>
-  <Module Id="30">
+  <Module Id="31">
     <Name>Qt SQL</Name>
     <Selectable>true</Selectable>
     <LibraryPrefix>QtSql</LibraryPrefix>
@@ -292,7 +300,7 @@
     <IncludePath>$(QTDIR)\include\QtSql</IncludePath>
     <Defines>QT_SQL_LIB</Defines>
   </Module>
-  <Module Id="31">
+  <Module Id="32">
     <Name>Qt State Machine</Name>
     <Selectable>true</Selectable>
     <LibraryPrefix>QtStateMachine</LibraryPrefix>
@@ -300,7 +308,7 @@
     <IncludePath>$(QTDIR)\include\QtStateMachine</IncludePath>
     <Defines>QT_STATEMACHINE_LIB</Defines>
   </Module>
-  <Module Id="32">
+  <Module Id="33">
     <Name>Qt SVG</Name>
     <Selectable>true</Selectable>
     <LibraryPrefix>QtSvg</LibraryPrefix>


### PR DESCRIPTION
The modules list for qt6 did not include OpenGLWidgets. This has been added.
The resource compiler properties did not allow for --no-zstd which is generated by default by qmake with the community download of qt6.
Both of these caused conversions and builds to fail.