### PR TITLE
Separate debug and release project folders

### DIFF
--- a/QtVsTools.Core/CMake/CMakeProject.Presets.cs
+++ b/QtVsTools.Core/CMake/CMakeProject.Presets.cs
@@ -171,7 +171,7 @@ namespace QtVsTools.Core.CMake
                 {
                     ["name"] = "Qt-Release",
                     ["inherits"] = "Qt-Default",
-                    ["binaryDir"] = "${sourceDir}/out/build",
+                    ["binaryDir"] = "${sourceDir}/out/build/release",
                     ["cacheVariables"] = new JObject
                     {
                         ["CMAKE_BUILD_TYPE"] = "Release"
@@ -181,7 +181,7 @@ namespace QtVsTools.Core.CMake
                 {
                     ["name"] = "Qt-Debug",
                     ["inherits"] = "Qt-Default",
-                    ["binaryDir"] = "${sourceDir}/out/build",
+                    ["binaryDir"] = "${sourceDir}/out/build/debug",
                     ["cacheVariables"] = new JObject
                     {
                         ["CMAKE_BUILD_TYPE"] = "Debug",

--- a/QtVsTools.Wizards/ProjectWizard/ProjectTemplateWizard.CMake.cs
+++ b/QtVsTools.Wizards/ProjectWizard/ProjectTemplateWizard.CMake.cs
@@ -145,7 +145,7 @@ namespace QtVsTools.Wizards.ProjectWizard
             {
                 Name = $"{config.Name}-{config.Platform}",
                 DisplayName = $"{config.Name} ({config.Platform})",
-                BinaryDir = "${sourceDir}/out/build",
+                BinaryDir = "${sourceDir}/out/build/" + (config.IsDebug ? "debug" : "release"),
                 CacheVariables = new CMakeConfigPreset.ConfigCacheVariables
                 {
                     CMakeBuildType = config.IsDebug ? "Debug" : "Release"


### PR DESCRIPTION
If the project folder is the same (/out/build) for both builds debug and release sometimes happens with Visual Studio when some changes are made to the code and you switch from release to debug the source object file is not updated and, consequently, the breakpoints do not work. Configure a separate folder for debug and release seems to fix this problem.